### PR TITLE
Add the ability to force moderation on posting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,6 +6,11 @@ en:
     geo_blocking_log_blocked: "Log blocked IP addresses."
     geo_blocking_log_allowed: "Log allowed IP addresses."
     geo_blocking_detailed_reason: "Provide details of the block reason to the user."
+    geo_moderating_asn_blocklist: "List of ASNs to moderate. You must include AS before the number."
+    geo_moderating_country_region_blocklist: "List of countries and regions to moderate. Format: XX (country ISO code) or Countryname or Countryname.Regionname"
+    geo_moderating_log_blocked: "Log moderate IP addresses."
+    geo_moderating_log_allowed: "Log allowed IP addresses."
+    geo_moderating_detailed_reason: "Provide details of the moderate reason to the user."
   geo_blocking: 
     error_451: "This community is not accessible in your location."
     error_451_detailed: "This community is not accessible because you are in %{reason}."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,6 +20,25 @@ plugins:
   geo_blocking_log_allowed:
     client: false
     default: false
+  geo_moderating_asn_blocklist:
+    client: false
+    default: ""
+    type: list
+    list_type: simple
+  geo_moderating_country_region_blocklist:
+    client: false
+    default: ""
+    type: list
+    list_type: simple
+  geo_moderating_detailed_reason:
+    client: false
+    default: true
+  geo_moderating_log_blocked:
+    client: false
+    default: false
+  geo_moderating_log_allowed:
+    client: false
+    default: false
   geo_blocking_cache_version:
     hidden: true
     client: false

--- a/lib/geo_blocking/lookup.rb
+++ b/lib/geo_blocking/lookup.rb
@@ -23,60 +23,60 @@ module GeoBlocking
       @reason
     end
 
-    def self.lookup_moderate?(ip)
+    def self.lookup(ip, configuration)
       ipinfo = DiscourseIpInfo.get(ip)
       return false unless ipinfo && ipinfo[:asn]
 
-      if SiteSetting.geo_moderating_asn_blocklist.split("|").include?("AS#{ipinfo[:asn]}")
-        if SiteSetting.geo_moderating_log_blocked
-          Rails.logger.warn "Geo-moderating IP #{ip} because it is in network AS#{ipinfo[:asn]}"
+      if configuration == 'block'
+        asn_blocklist = SiteSetting.get_blocking_asn_blocklist
+        log_blocked = SiteSetting.get_blocking_log_blocked
+        country_region_blocklist = SiteSetting.geo_blocking_country_region_blocklist
+        action = 'blocking'
+        log_allowed = SiteSetting.geo_blocking_log_allowed
+      elsif configuration == 'moderate'
+        asn_blocklist = SiteSetting.get_moderating_asn_blocklist
+        log_blocked = SiteSetting.get_moderating_log_blocked
+        country_region_blocklist = SiteSetting.geo_moderating_country_region_blocklist
+        action = 'moderating'
+        log_allowed = SiteSetting.geo_moderating_log_allowed
+      else
+        return false
+      end
+
+      if asn_blocklist.split("|").include?("AS#{ipinfo[:asn]}")
+        if log_blocked
+          Rails.logger.warn "Geo-#{action} IP #{ip} because it is in network AS#{ipinfo[:asn]}"
         end
         return "network AS-#{ipinfo[:asn]}"
       end
 
-      crlist = SiteSetting.geo_moderating_country_region_blocklist.split("|")
+      crlist = country_region_blocklist.split("|")
       if crlist.include?(ipinfo[:country]) || crlist.include?(ipinfo[:country_code])
-        if SiteSetting.geo_moderating_log_blocked
-          Rails.logger.warn "Geo-moderating IP #{ip} because it is in country #{ipinfo[:country]}"
+        if log_blocked
+          Rails.logger.warn "Geo-#{action} IP #{ip} because it is in country #{ipinfo[:country]}"
         end
         return "#{ipinfo[:country]}"
       end
 
       if crlist.include?("#{ipinfo[:country]}.#{ipinfo[:region]}")
-        if SiteSetting.geo_moderating_log_blocked
-          Rails.logger.warn "Geo-moderating IP #{ip} because it is in region #{ipinfo[:country]}.#{ipinfo[:region]}"
+        if log_blocked
+          Rails.logger.warn "Geo-#{action} IP #{ip} because it is in region #{ipinfo[:country]}.#{ipinfo[:region]}"
         end
         return "#{ipinfo[:region]}, #{ipinfo[:country]}"
       end
 
-      if SiteSetting.geo_moderating_log_allowed
-        Rails.logger.warn "Not geo-moderating IP #{ip} - network: AS#{ipinfo[:asn]}, country: #{ipinfo[:country]} (#{ipinfo[:country_code]}), region: #{ipinfo[:region]}"
+      if log_allowed
+        Rails.logger.warn "Not geo-#{action} IP #{ip} - network: AS#{ipinfo[:asn]}, country: #{ipinfo[:country]} (#{ipinfo[:country_code]}), region: #{ipinfo[:region]}"
       end
       return false
     end
 
+    def self.lookup_moderate?(ip)
+      lookup(ip, 'moderate')
+    end
+
     def self.lookup_block?(ip)
-      ipinfo = DiscourseIpInfo.get(ip)
-      return false unless ipinfo && ipinfo[:asn]
-
-      if SiteSetting.geo_blocking_asn_blocklist.split("|").include?("AS#{ipinfo[:asn]}")
-        Rails.logger.warn "Geo-blocking IP #{ip} because it is in network AS#{ipinfo[:asn]}" if SiteSetting.geo_blocking_log_blocked
-        return "network AS-#{ipinfo[:asn]}"
-      end
-
-      crlist = SiteSetting.geo_blocking_country_region_blocklist.split("|")
-      if crlist.include?(ipinfo[:country]) || crlist.include?(ipinfo[:country_code])
-        Rails.logger.warn "Geo-blocking IP #{ip} because it is in country #{ipinfo[:country]}" if SiteSetting.geo_blocking_log_blocked
-        return "#{ipinfo[:country]}"
-      end
-
-      if crlist.include?("#{ipinfo[:country]}.#{ipinfo[:region]}")
-        Rails.logger.warn "Geo-blocking IP #{ip} because it is in region #{ipinfo[:country]}.#{ipinfo[:region]}" if SiteSetting.geo_blocking_log_blocked
-        return "#{ipinfo[:region]}, #{ipinfo[:country]}"
-      end
-
-      Rails.logger.warn "Not geo-blocking IP #{ip} - network: AS#{ipinfo[:asn]}, country: #{ipinfo[:country]} (#{ipinfo[:country_code]}), region: #{ipinfo[:region]}" if SiteSetting.geo_blocking_log_allowed
-      return false
+      lookup(ip, 'block')
     end
   end
 end

--- a/lib/geo_blocking/lookup.rb
+++ b/lib/geo_blocking/lookup.rb
@@ -4,11 +4,56 @@ module GeoBlocking
   class Lookup
     def self.is_blocked?(ip)
       version = SiteSetting.geo_blocking_cache_version
-      @reason = Rails.cache.fetch("geoblocking/#{version}/#{ip}", expires_in: 24.hours) do 
-        lookup_block?(ip)
-      end
+      @reason =
+        Rails
+          .cache
+          .fetch("geoblocking/#{version}/#{ip}", expires_in: 24.hours) { lookup_block?(ip) }
 
       @reason
+    end
+
+    def self.is_moderated?(ip)
+      version = SiteSetting.geo_blocking_cache_version
+      @reason =
+        Rails
+          .cache
+          .fetch("geoblocking-moderate/#{version}/#{ip}", expires_in: 24.hours) do
+            lookup_moderate?(ip)
+          end
+
+      @reason
+    end
+
+    def self.lookup_moderate?(ip)
+      ipinfo = DiscourseIpInfo.get(ip)
+      return false unless ipinfo && ipinfo[:asn]
+
+      if SiteSetting.geo_moderating_asn_blocklist.split("|").include?("AS#{ipinfo[:asn]}")
+        if SiteSetting.geo_moderating_log_blocked
+          Rails.logger.warn "Geo-moderating IP #{ip} because it is in network AS#{ipinfo[:asn]}"
+        end
+        return "network AS-#{ipinfo[:asn]}"
+      end
+
+      crlist = SiteSetting.geo_moderating_country_region_blocklist.split("|")
+      if crlist.include?(ipinfo[:country]) || crlist.include?(ipinfo[:country_code])
+        if SiteSetting.geo_moderating_log_blocked
+          Rails.logger.warn "Geo-moderating IP #{ip} because it is in country #{ipinfo[:country]}"
+        end
+        return "#{ipinfo[:country]}"
+      end
+
+      if crlist.include?("#{ipinfo[:country]}.#{ipinfo[:region]}")
+        if SiteSetting.geo_moderating_log_blocked
+          Rails.logger.warn "Geo-moderating IP #{ip} because it is in region #{ipinfo[:country]}.#{ipinfo[:region]}"
+        end
+        return "#{ipinfo[:region]}, #{ipinfo[:country]}"
+      end
+
+      if SiteSetting.geo_moderating_log_allowed
+        Rails.logger.warn "Not geo-moderating IP #{ip} - network: AS#{ipinfo[:asn]}, country: #{ipinfo[:country]} (#{ipinfo[:country_code]}), region: #{ipinfo[:region]}"
+      end
+      return false
     end
 
     def self.lookup_block?(ip)
@@ -16,24 +61,31 @@ module GeoBlocking
       return false unless ipinfo && ipinfo[:asn]
 
       if SiteSetting.geo_blocking_asn_blocklist.split("|").include?("AS#{ipinfo[:asn]}")
-        Rails.logger.warn "Geo-blocking IP #{ip} because it is in network AS#{ipinfo[:asn]}" if SiteSetting.geo_blocking_log_blocked
+        if SiteSetting.geo_blocking_log_blocked
+          Rails.logger.warn "Geo-blocking IP #{ip} because it is in network AS#{ipinfo[:asn]}"
+        end
         return "network AS-#{ipinfo[:asn]}"
       end
 
       crlist = SiteSetting.geo_blocking_country_region_blocklist.split("|")
       if crlist.include?(ipinfo[:country]) || crlist.include?(ipinfo[:country_code])
-        Rails.logger.warn "Geo-blocking IP #{ip} because it is in country #{ipinfo[:country]}" if SiteSetting.geo_blocking_log_blocked
+        if SiteSetting.geo_blocking_log_blocked
+          Rails.logger.warn "Geo-blocking IP #{ip} because it is in country #{ipinfo[:country]}"
+        end
         return "#{ipinfo[:country]}"
       end
 
       if crlist.include?("#{ipinfo[:country]}.#{ipinfo[:region]}")
-        Rails.logger.warn "Geo-blocking IP #{ip} because it is in region #{ipinfo[:country]}.#{ipinfo[:region]}" if SiteSetting.geo_blocking_log_blocked
+        if SiteSetting.geo_blocking_log_blocked
+          Rails.logger.warn "Geo-blocking IP #{ip} because it is in region #{ipinfo[:country]}.#{ipinfo[:region]}"
+        end
         return "#{ipinfo[:region]}, #{ipinfo[:country]}"
       end
 
-      Rails.logger.warn "Not geo-blocking IP #{ip} - network: AS#{ipinfo[:asn]}, country: #{ipinfo[:country]} (#{ipinfo[:country_code]}), region: #{ipinfo[:region]}" if SiteSetting.geo_blocking_log_allowed
+      if SiteSetting.geo_blocking_log_allowed
+        Rails.logger.warn "Not geo-blocking IP #{ip} - network: AS#{ipinfo[:asn]}, country: #{ipinfo[:country]} (#{ipinfo[:country_code]}), region: #{ipinfo[:region]}"
+      end
       return false
     end
-
   end
 end

--- a/lib/geo_blocking/lookup.rb
+++ b/lib/geo_blocking/lookup.rb
@@ -4,10 +4,9 @@ module GeoBlocking
   class Lookup
     def self.is_blocked?(ip)
       version = SiteSetting.geo_blocking_cache_version
-      @reason =
-        Rails
-          .cache
-          .fetch("geoblocking/#{version}/#{ip}", expires_in: 24.hours) { lookup_block?(ip) }
+      @reason = Rails.cache.fetch("geoblocking/#{version}/#{ip}", expires_in: 24.hours) do 
+        lookup_block?(ip)
+      end
 
       @reason
     end
@@ -61,30 +60,22 @@ module GeoBlocking
       return false unless ipinfo && ipinfo[:asn]
 
       if SiteSetting.geo_blocking_asn_blocklist.split("|").include?("AS#{ipinfo[:asn]}")
-        if SiteSetting.geo_blocking_log_blocked
-          Rails.logger.warn "Geo-blocking IP #{ip} because it is in network AS#{ipinfo[:asn]}"
-        end
+        Rails.logger.warn "Geo-blocking IP #{ip} because it is in network AS#{ipinfo[:asn]}" if SiteSetting.geo_blocking_log_blocked
         return "network AS-#{ipinfo[:asn]}"
       end
 
       crlist = SiteSetting.geo_blocking_country_region_blocklist.split("|")
       if crlist.include?(ipinfo[:country]) || crlist.include?(ipinfo[:country_code])
-        if SiteSetting.geo_blocking_log_blocked
-          Rails.logger.warn "Geo-blocking IP #{ip} because it is in country #{ipinfo[:country]}"
-        end
+        Rails.logger.warn "Geo-blocking IP #{ip} because it is in country #{ipinfo[:country]}" if SiteSetting.geo_blocking_log_blocked
         return "#{ipinfo[:country]}"
       end
 
       if crlist.include?("#{ipinfo[:country]}.#{ipinfo[:region]}")
-        if SiteSetting.geo_blocking_log_blocked
-          Rails.logger.warn "Geo-blocking IP #{ip} because it is in region #{ipinfo[:country]}.#{ipinfo[:region]}"
-        end
+        Rails.logger.warn "Geo-blocking IP #{ip} because it is in region #{ipinfo[:country]}.#{ipinfo[:region]}" if SiteSetting.geo_blocking_log_blocked
         return "#{ipinfo[:region]}, #{ipinfo[:country]}"
       end
 
-      if SiteSetting.geo_blocking_log_allowed
-        Rails.logger.warn "Not geo-blocking IP #{ip} - network: AS#{ipinfo[:asn]}, country: #{ipinfo[:country]} (#{ipinfo[:country_code]}), region: #{ipinfo[:region]}"
-      end
+      Rails.logger.warn "Not geo-blocking IP #{ip} - network: AS#{ipinfo[:asn]}, country: #{ipinfo[:country]} (#{ipinfo[:country_code]}), region: #{ipinfo[:region]}" if SiteSetting.geo_blocking_log_allowed
       return false
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -6,41 +6,79 @@
 
 enabled_site_setting :geo_blocking_enabled
 
-load File.expand_path('lib/geo_blocking/lookup.rb', __dir__)
+load File.expand_path("lib/geo_blocking/lookup.rb", __dir__)
 
 after_initialize do
-  ::ActionController::Base.prepend_view_path File.expand_path('../app/views', __FILE__)
+  ::ActionController::Base.prepend_view_path File.expand_path("../app/views", __FILE__)
 
   ApplicationController.class_eval do
     alias_method :_old_rescue_discourse_actions, :rescue_discourse_actions
 
     DiscourseEvent.on(:site_setting_changed) do |name|
-      if [:geo_blocking_asn_blocklist, :geo_blocking_country_region_blocklist].include? name
-        SiteSetting.geo_blocking_cache_version  = SiteSetting.geo_blocking_cache_version + 1
+      if %i[geo_blocking_asn_blocklist geo_blocking_country_region_blocklist].include? name
+        SiteSetting.geo_blocking_cache_version = SiteSetting.geo_blocking_cache_version + 1
       end
     end
 
     def rescue_discourse_actions(type, status_code, opts = nil)
-      if SiteSetting.geo_blocking_enabled
-        @hide_content = (status_code == 451)
-      end
+      @hide_content = (status_code == 451) if SiteSetting.geo_blocking_enabled
       _old_rescue_discourse_actions(type, status_code, opts)
     end
   end
 
+  User.register_custom_field_type("last_ip_address", :string)
+
+  module ::DiscourseForceModeration
+    def post_needs_approval?(manager)
+      superResult = super
+      return superResult if ((!(SiteSetting.geo_blocking_enabled)) || (superResult != :skip))
+
+      reason = ::GeoBlocking::Lookup.is_moderated?(manager.user.custom_fields["last_ip_address"])
+      Rails.logger.warn(reason)
+      return unless reason
+
+      :skip
+    end
+  end
+
+  NewPostManager.singleton_class.prepend ::DiscourseForceModeration
+
   add_model_callback(:application_controller, :before_action) do
     return unless SiteSetting.geo_blocking_enabled
-    return if request.fullpath.start_with?("/admin/", "/message-bus/", "/theme-javascripts/", "/stylesheets/", "/letter_avatar_proxy/", "/svg-sprite/", "/extra-locales/")
+    if request.fullpath.start_with?(
+         "/admin/",
+         "/message-bus/",
+         "/theme-javascripts/",
+         "/stylesheets/",
+         "/letter_avatar_proxy/",
+         "/svg-sprite/",
+         "/extra-locales/",
+       )
+      return
+    end
 
-    ip = request.env['HTTP_X_REAL_IP'] || request.env['REMOTE_ADDR']
+    ip = request.env["HTTP_X_REAL_IP"] || request.env["REMOTE_ADDR"]
+
+    user = current_user
+    user.custom_fields["last_ip_address"] = ip
+    user.save_custom_fields(true)
+
     reason = ::GeoBlocking::Lookup.is_blocked?(ip)
     return unless reason
 
     if SiteSetting.geo_blocking_detailed_reason
-      rescue_discourse_actions(:unavailable, 451, {custom_message: "geo_blocking.error_451_detailed",  custom_message_params: { reason: reason }})
+      rescue_discourse_actions(
+        :unavailable,
+        451,
+        {
+          custom_message: "geo_blocking.error_451_detailed",
+          custom_message_params: {
+            reason: reason,
+          },
+        },
+      )
     else
-      rescue_discourse_actions(:unavailable, 451, {custom_message: "geo_blocking.error_451" })
+      rescue_discourse_actions(:unavailable, 451, { custom_message: "geo_blocking.error_451" })
     end
   end
-
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -51,8 +51,10 @@ after_initialize do
     ip = request.env["HTTP_X_REAL_IP"] || request.env["REMOTE_ADDR"]
 
     user = current_user
-    user.custom_fields["last_ip_address"] = ip
-    user.save_custom_fields(true)
+    if user
+      user.custom_fields["last_ip_address"] = ip
+      user.save_custom_fields(true)
+    end
 
     reason = ::GeoBlocking::Lookup.is_blocked?(ip)
     return unless reason


### PR DESCRIPTION
Add the ability to mark a post from an ip address with the matching criteria to wait for moderation.

This change basically takes the mechanism that exists to block access and use it to force moderation on posts.
It duplicates configuration to apply to moderation.
It adds last known ip address to the logged in user to mark their posts.
And finally it overwrites `post_needs_approval` to force moderation.

[Context on this thread.](https://meta.discourse.org/t/blocking-recent-wave-of-spam/314867)